### PR TITLE
add .binder/Dockerfile and binder button to README.md

### DIFF
--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -1,0 +1,13 @@
+FROM rocker/binder:3.6.0
+LABEL maintainer='Daniel Nüst'
+USER root
+RUN tlmgr init-usertree \
+ && tlmgr update --self \
+ && tlmgr install pgf environ placeins psnfss titlesec trimspaces palatino mathpazo setspace microtype xcolor fancyhdr 
+COPY . ${HOME}
+RUN chown -R ${NB_USER} ${HOME}
+USER ${NB_USER}
+
+RUN wget https://github.com/benmarwick/rockerverse-paper/raw/master/DESCRIPTION && R -e "options(repos = list(CRAN = 'http://mran.revolutionanalytics.com/snapshot/2019-11-09/')); devtools::install_deps()"
+
+RUN rm DESCRIPTION.1; exit 0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,17 @@
+Type: Compendium
+Package: compendium
+Title: What the Package Does (One Line, Title Case)
+Version: 0.0.1
+Authors@R: 
+    person(given = "Ben",
+           family = "Marwick",
+           role = c("aut", "cre"),
+           email = "benmarwick@gmail.com",
+           comment = c(ORCID = "0000-0001-7879-4531"))
+Description: Rockerverse paper
+License: MIT + file LICENSE
+Depends: 
+    rmarkdown,
+    rticles
+Encoding: UTF-8
+LazyData: true

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Rockerverse
 
 <!-- badges: start -->
-[![Launch Rstudio Binder](http://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/benmarwick/rockerverse-paper/master?urlpath=rstudio)
+[![Launch RStudio Binder](http://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/nuest/rockerverse-paper/master?urlpath=rstudio)
 <!-- badges: end -->
 
-Draft for an article of everything related to containers and R, based on http://bit.ly/docker-r.
+Draft for an article of everything related to containers and R, originally based on the blog post http://bit.ly/docker-r.
 
 _Want to contribute?_ See https://github.com/nuest/rockerverse-paper/issues/3.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Rockerverse
 
+<!-- badges: start -->
+[![Launch Rstudio Binder](http://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/benmarwick/rockerverse-paper/master?urlpath=rstudio)
+<!-- badges: end -->
+
 Draft for an article of everything related to containers and R, based on http://bit.ly/docker-r.
 
 _Want to contribute?_ See https://github.com/nuest/rockerverse-paper/issues/3.


### PR DESCRIPTION
This adds a binder button to the readme, which when clicked, will use the dockerfile in `.binder` to start a binder instance and give the user RStudio in their browser where they can knit the Rmd document to PDF. Seems fitting for the paper repo to have this, since it's mentioned in the manuscript. We'll need to update the URL for the binder button after merging, since I have kept it at my GitHub repo URL so we can test that it works before merging. 