### PR TITLE
install extra packages in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,8 @@ RUN r -e 'tinytex::tlmgr_update(); tinytex::tlmgr_install(pkgs = c("pgf", \
     "microtype", \
     "xcolor", \
     "fancyhdr"))'
+
+RUN r -e 'install.packages("kableExtra")'
+
+# until https://github.com/rstudio/rticles/pull/261 is merged
+RUN r -e 'devtools::install_github("rcannood/rticles")'


### PR DESCRIPTION
* kableExtra is needed for the table that I added to the manuscript
* Current version of rticles allow to specify extra latex packages (See rstudio/rticles#261)